### PR TITLE
Removed some deprecated Rspec syntax

### DIFF
--- a/spec/draper/collection_decorator_spec.rb
+++ b/spec/draper/collection_decorator_spec.rb
@@ -168,7 +168,7 @@ module Draper
           decorator = CollectionDecorator.new(object)
           other = ProductsDecorator.new(object)
 
-          expect(decorator == other).to be_true
+          expect(decorator == other).to be_truthy
         end
       end
 
@@ -177,7 +177,7 @@ module Draper
           decorator = CollectionDecorator.new([Product.new, Product.new])
           other = ProductsDecorator.new([Product.new, Product.new])
 
-          expect(decorator == other).to be_false
+          expect(decorator == other).to be_falsey
         end
       end
 
@@ -187,7 +187,7 @@ module Draper
           decorator = CollectionDecorator.new(object)
           other = object.dup
 
-          expect(decorator == other).to be_true
+          expect(decorator == other).to be_truthy
         end
       end
 
@@ -196,7 +196,7 @@ module Draper
           decorator = CollectionDecorator.new([Product.new, Product.new])
           other = [Product.new, Product.new]
 
-          expect(decorator == other).to be_false
+          expect(decorator == other).to be_falsey
         end
       end
 
@@ -207,7 +207,7 @@ module Draper
           other = object.dup
 
           decorator << Product.new.decorate
-          expect(decorator == other).to be_false
+          expect(decorator == other).to be_falsey
         end
       end
     end

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -48,21 +48,21 @@ module Draper
 
     describe "#decorator_class?" do
       it "returns true for decoratable model" do
-        expect(Product.new.decorator_class?).to be_true
+        expect(Product.new.decorator_class?).to be_truthy
       end
 
       it "returns false for non-decoratable model" do
-        expect(Model.new.decorator_class?).to be_false
+        expect(Model.new.decorator_class?).to be_falsey
       end
     end
 
     describe ".decorator_class?" do
       it "returns true for decoratable model" do
-        expect(Product.decorator_class?).to be_true
+        expect(Product.decorator_class?).to be_truthy
       end
 
       it "returns false for non-decoratable model" do
-        expect(Model.decorator_class?).to be_false
+        expect(Model.decorator_class?).to be_falsey
       end
     end
 
@@ -84,46 +84,46 @@ module Draper
         product = Product.new
 
         product.should_receive(:==).and_return(true)
-        expect(product === :anything).to be_true
+        expect(product === :anything).to be_truthy
       end
 
       it "is false when #== is false" do
         product = Product.new
 
         product.should_receive(:==).and_return(false)
-        expect(product === :anything).to be_false
+        expect(product === :anything).to be_falsey
       end
     end
 
     describe ".====" do
       it "is true for an instance" do
-        expect(Product === Product.new).to be_true
+        expect(Product === Product.new).to be_truthy
       end
 
       it "is true for a derived instance" do
-        expect(Product === Class.new(Product).new).to be_true
+        expect(Product === Class.new(Product).new).to be_truthy
       end
 
       it "is false for an unrelated instance" do
-        expect(Product === Model.new).to be_false
+        expect(Product === Model.new).to be_falsey
       end
 
       it "is true for a decorated instance" do
         decorator = double(object: Product.new)
 
-        expect(Product === decorator).to be_true
+        expect(Product === decorator).to be_truthy
       end
 
       it "is true for a decorated derived instance" do
         decorator = double(object: Class.new(Product).new)
 
-        expect(Product === decorator).to be_true
+        expect(Product === decorator).to be_truthy
       end
 
       it "is false for a decorated unrelated instance" do
         decorator = double(object: Model.new)
 
-        expect(Product === decorator).to be_false
+        expect(Product === decorator).to be_falsey
       end
     end
 

--- a/spec/draper/decoratable_spec.rb
+++ b/spec/draper/decoratable_spec.rb
@@ -192,7 +192,7 @@ module Draper
 
       context "when an unrelated NameError is thrown" do
         it "re-raises that error" do
-          String.any_instance.stub(:constantize).and_return{Draper::Base}
+          String.any_instance.stub(:constantize) { Draper::Base }
           expect{Product.decorator_class}.to raise_error NameError, /Draper::Base/
         end
       end

--- a/spec/draper/decorated_association_spec.rb
+++ b/spec/draper/decorated_association_spec.rb
@@ -29,7 +29,7 @@ module Draper
 
       describe ":context option" do
         it "defaults to the identity function" do
-          Factory.should_receive(:new).with do |options|
+          Factory.should_receive(:new) do |options|
             options[:context].call(:anything) == :anything
           end
           DecoratedAssociation.new(double, :association, {})

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -73,7 +73,7 @@ module Draper
           decorated = OtherDecorator.new(Decorator.new(Model.new))
 
           warning_message = nil
-          Object.any_instance.stub(:warn) {|message| warning_message = message }
+          Object.any_instance.stub(:warn) { |instance, message| warning_message = message }
 
           expect{Decorator.new(decorated)}.to change{warning_message}
           expect(warning_message).to start_with "Reapplying Draper::Decorator"

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -222,19 +222,19 @@ module Draper
       it "returns truthy when .object_class is set" do
         Decorator.stub(:object_class).and_return(Model)
 
-        expect(Decorator.object_class?).to be_true
+        expect(Decorator.object_class?).to be_truthy
       end
 
       it "returns false when .object_class is not inferrable" do
         Decorator.stub(:object_class).and_raise(UninferrableSourceError.new(Decorator))
 
-        expect(Decorator.object_class?).to be_false
+        expect(Decorator.object_class?).to be_falsey
       end
 
       it "is aliased to .source_class?" do
         Decorator.stub(:object_class).and_return(Model)
 
-        expect(Decorator.source_class?).to be_true
+        expect(Decorator.source_class?).to be_truthy
       end
     end
 
@@ -514,7 +514,7 @@ module Draper
         other = double(object: Model.new)
 
         object.should_receive(:==).with(other).and_return(true)
-        expect(decorator == other).to be_true
+        expect(decorator == other).to be_truthy
       end
 
       it "is false when object #== is false" do
@@ -523,7 +523,7 @@ module Draper
         other = double(object: Model.new)
 
         object.should_receive(:==).with(other).and_return(false)
-        expect(decorator == other).to be_false
+        expect(decorator == other).to be_falsey
       end
 
     end
@@ -533,14 +533,14 @@ module Draper
         decorator = Decorator.new(Model.new)
         decorator.stub(:==).with(:anything).and_return(true)
 
-        expect(decorator === :anything).to be_true
+        expect(decorator === :anything).to be_truthy
       end
 
       it "is false when #== is false" do
         decorator = Decorator.new(Model.new)
         decorator.stub(:==).with(:anything).and_return(false)
 
-        expect(decorator === :anything).to be_false
+        expect(decorator === :anything).to be_falsey
       end
     end
 
@@ -659,14 +659,14 @@ module Draper
             Decorator.class_eval{private; def hello_world; end}
             decorator = Decorator.new(Model.new)
 
-            expect(decorator.respond_to?(:hello_world, true)).to be_true
+            expect(decorator.respond_to?(:hello_world, true)).to be_truthy
           end
 
           it "returns false for the object's private methods" do
             object = Class.new{private; def hello_world; end}.new
             decorator = Decorator.new(object)
 
-            expect(decorator.respond_to?(:hello_world, true)).to be_false
+            expect(decorator.respond_to?(:hello_world, true)).to be_falsey
           end
         end
       end
@@ -722,27 +722,27 @@ module Draper
       it "pretends to be a kind of the source class" do
         decorator = Decorator.new(Model.new)
 
-        expect(decorator.kind_of?(Model)).to be_true
-        expect(decorator.is_a?(Model)).to be_true
+        expect(decorator.kind_of?(Model)).to be_truthy
+        expect(decorator.is_a?(Model)).to be_truthy
       end
 
       it "is still a kind of its own class" do
         decorator = Decorator.new(Model.new)
 
-        expect(decorator.kind_of?(Decorator)).to be_true
-        expect(decorator.is_a?(Decorator)).to be_true
+        expect(decorator.kind_of?(Decorator)).to be_truthy
+        expect(decorator.is_a?(Decorator)).to be_truthy
       end
 
       it "pretends to be an instance of the source class" do
         decorator = Decorator.new(Model.new)
 
-        expect(decorator.instance_of?(Model)).to be_true
+        expect(decorator.instance_of?(Model)).to be_truthy
       end
 
       it "is still an instance of its own class" do
         decorator = Decorator.new(Model.new)
 
-        expect(decorator.instance_of?(Decorator)).to be_true
+        expect(decorator.instance_of?(Decorator)).to be_truthy
       end
     end
 

--- a/spec/draper/decorator_spec.rb
+++ b/spec/draper/decorator_spec.rb
@@ -148,7 +148,7 @@ module Draper
 
       context "when a NameError is thrown" do
         it "re-raises that error" do
-          String.any_instance.stub(:constantize).and_return{Draper::DecoratedEnumerableProxy}
+          String.any_instance.stub(:constantize) { Draper::DecoratedEnumerableProxy }
           expect{ProductDecorator.decorate_collection([])}.to raise_error NameError, /Draper::DecoratedEnumerableProxy/
         end
       end
@@ -207,7 +207,7 @@ module Draper
 
         context "when an unrelated NameError is thrown" do
           it "re-raises that error" do
-            String.any_instance.stub(:constantize).and_return{SomethingThatDoesntExist}
+            String.any_instance.stub(:constantize) { SomethingThatDoesntExist }
             expect{ProductDecorator.object_class}.to raise_error NameError, /SomethingThatDoesntExist/
           end
         end
@@ -580,7 +580,7 @@ module Draper
 
         it "passes blocks to delegated methods" do
           object = Model.new
-          object.stub(:hello_world).and_return{|*args, &block| block.call}
+          object.stub(:hello_world) { |*args, &block| block.call }
           decorator = Decorator.new(object)
 
           expect(decorator.hello_world{:yielded}).to be :yielded

--- a/spec/draper/helper_proxy_spec.rb
+++ b/spec/draper/helper_proxy_spec.rb
@@ -43,7 +43,7 @@ module Draper
       it "allows #method to be called on the view context" do
         helper_proxy = HelperProxy.new(double(foo: "bar"))
 
-        expect(helper_proxy.respond_to?(:foo)).to be_true
+        expect(helper_proxy.respond_to?(:foo)).to be_truthy
       end
     end
 

--- a/spec/draper/helper_proxy_spec.rb
+++ b/spec/draper/helper_proxy_spec.rb
@@ -18,7 +18,7 @@ module Draper
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
-        view_context.stub(:foo).and_return{|arg| arg}
+        view_context.stub(:foo) { |arg| arg }
         expect(helper_proxy.foo(:passed)).to be :passed
       end
 
@@ -26,7 +26,7 @@ module Draper
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
-        view_context.stub(:foo).and_return{|&block| block.call}
+        view_context.stub(:foo) { |&block| block.call }
         expect(helper_proxy.foo{:yielded}).to be :yielded
       end
 
@@ -52,7 +52,7 @@ module Draper
         view_context = double
         helper_proxy = HelperProxy.new(view_context)
 
-        view_context.stub(:capture).and_return{|*args, &block| [*args, block.call] }
+        view_context.stub(:capture) { |*args, &block| [*args, block.call] }
         expect(helper_proxy.capture(:first_arg, :second_arg){:yielded}).to \
           be_eql [:first_arg, :second_arg, :yielded]
       end

--- a/spec/draper/lazy_helpers_spec.rb
+++ b/spec/draper/lazy_helpers_spec.rb
@@ -8,12 +8,12 @@ module Draper
       end
 
       it "proxies methods to #helpers" do
-        decorator.helpers.stub(:foo).and_return{|arg| arg}
+        decorator.helpers.stub(:foo) { |arg| arg }
         expect(decorator.foo(:passed)).to be :passed
       end
 
       it "passes blocks" do
-        decorator.helpers.stub(:foo).and_return{|&block| block.call}
+        decorator.helpers.stub(:foo) { |&block| block.call }
         expect(decorator.foo{:yielded}).to be :yielded
       end
     end

--- a/spec/draper/view_context_spec.rb
+++ b/spec/draper/view_context_spec.rb
@@ -131,7 +131,7 @@ module Draper
         end
 
         it "passes a block to the strategy" do
-          ViewContext::BuildStrategy::Fast.stub(:new).and_return{|&block| block.call}
+          ViewContext::BuildStrategy::Fast.stub(:new) { |&block| block.call }
 
           expect(ViewContext.test_strategy(:fast){:passed}).to be :passed
         end
@@ -144,7 +144,7 @@ module Draper
         end
 
         it "passes a block to the strategy" do
-          ViewContext::BuildStrategy::Full.stub(:new).and_return{|&block| block.call}
+          ViewContext::BuildStrategy::Full.stub(:new) { |&block| block.call }
 
           expect(ViewContext.test_strategy(:full){:passed}).to be :passed
         end

--- a/spec/dummy/spec/decorators/spec_type_spec.rb
+++ b/spec/dummy/spec/decorators/spec_type_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe "A spec in this folder" do
   it "is a decorator spec" do
-    expect(example.metadata[:type]).to be :decorator
+    expect(RSpec.current_example.metadata[:type]).to be :decorator
   end
 end

--- a/spec/dummy/spec/shared_examples/decoratable.rb
+++ b/spec/dummy/spec/shared_examples/decoratable.rb
@@ -4,7 +4,7 @@ shared_examples_for "a decoratable model" do
       described_class.create
       decorated = described_class.limit(1).decorate
 
-      expect(decorated).to have(1).items
+      expect(decorated.size).to eq(1)
       expect(decorated).to be_decorated
     end
   end
@@ -18,7 +18,7 @@ shared_examples_for "a decoratable model" do
       other = described_class.first
 
       expect(one).not_to be other
-      expect(one == other.decorate).to be_true
+      expect(one == other.decorate).to be_truthy
     end
   end
 end

--- a/spec/generators/decorator/decorator_generator_spec.rb
+++ b/spec/generators/decorator/decorator_generator_spec.rb
@@ -40,9 +40,8 @@ describe Rails::Generators::DecoratorGenerator do
 
       context "with an ApplicationDecorator" do
         before do
-          Object.any_instance.stub(:require).with("application_decorator").and_return do
-            stub_const "ApplicationDecorator", Class.new
-          end
+          Object.any_instance.stub(:require).with("application_decorator").and_return (
+            stub_const "ApplicationDecorator", Class.new)
         end
 
         before { run_generator %w(YourModel) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.expect_with(:rspec) {|c| c.syntax = :expect}
   config.order = :random
+  config.mock_with :rspec do |mocks|
+    mocks.yield_receiver_to_any_instance_implementation_blocks = true
+  end
 end
 
 class Model; include Draper::Decoratable; end

--- a/spec/support/shared_examples/decoratable_equality.rb
+++ b/spec/support/shared_examples/decoratable_equality.rb
@@ -1,40 +1,40 @@
 shared_examples_for "decoration-aware #==" do |subject|
   it "is true for itself" do
-    expect(subject == subject).to be_true
+    expect(subject == subject).to be_truthy
   end
 
   it "is false for another object" do
-    expect(subject == Object.new).to be_false
+    expect(subject == Object.new).to be_falsey
   end
 
   it "is true for a decorated version of itself" do
     decorated = double(object: subject, decorated?: true)
 
-    expect(subject == decorated).to be_true
+    expect(subject == decorated).to be_truthy
   end
 
   it "is false for a decorated other object" do
     decorated = double(object: Object.new, decorated?: true)
 
-    expect(subject == decorated).to be_false
+    expect(subject == decorated).to be_falsey
   end
 
   it "is false for a decoratable object with a `object` association" do
     decoratable = double(object: subject, decorated?: false)
 
-    expect(subject == decoratable).to be_false
+    expect(subject == decoratable).to be_falsey
   end
 
   it "is false for an undecoratable object with a `object` association" do
     undecoratable = double(object: subject)
 
-    expect(subject == undecoratable).to be_false
+    expect(subject == undecoratable).to be_falsey
   end
 
   it "is true for a multiply-decorated version of itself" do
     decorated = double(object: subject, decorated?: true)
     redecorated = double(object: decorated, decorated?: true)
 
-    expect(subject == redecorated).to be_true
+    expect(subject == redecorated).to be_truthy
   end
 end


### PR DESCRIPTION
Went through and removed some of the obvious RSpec deprecations. Not quite sure how to handle blocks, will require more guidance to navigate through that and get it squared away.

3/9/2015 - We worked as a group on removing more RSpec deprecations. We believe we have it down to one. 
